### PR TITLE
Add modularising feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,15 @@ class MiniRouter {
     server.listen(port, callback);
   }
 
+  group(basePath, runGroupRoutes) {
+    const previousBase = this.basePath;
+    this.basePath = basePath;
+
+    runGroupRoutes(this);
+
+    this.basePath = previousBase;
+  }
+
   use(handler) {
     this.middlewares.push(handler);
   }

--- a/index.js
+++ b/index.js
@@ -12,26 +12,32 @@ class MiniRouter {
     };
 
     this.middlewares = [];
+    this.basePath = "";
+  }
+
+  register(method, path, handlers) {
+    const newPath = this.basePath + path;
+    this.routes[method][newPath] = handlers;
   }
 
   get(path, ...handlers) {
-    this.routes.GET[path] = handlers;
+    this.register("GET", path, handlers);
   }
 
   post(path, ...handlers) {
-    this.routes.POST[path] = handlers;
+    this.register("POST", path, handlers);
   }
 
   put(path, ...handlers) {
-    this.routes.PUT[path] = handlers;
+    this.register("PUT", path, handlers);
   }
 
   patch(path, ...handlers) {
-    this.routes.PATCH[path] = handlers;
+    this.register("PATCH", path, handlers);
   }
 
   delete(path, ...handlers) {
-    this.routes.DELETE[path] = handlers;
+    this.register("DELETE", path, handlers);
   }
 
   listen(port, callback) {

--- a/server.js
+++ b/server.js
@@ -13,11 +13,16 @@ app.use((req, res, next) => {
   }
 })
 
-app.get("/api", apiController.getHandler);
+app.group("/api", function(app) {
+  app.get("/users/:id", apiController.getUserHandler);
+  app.post("/", middleware.mwOne, middleware.mwTwo, apiController.postHandler);
+});
 
-app.get("/api/users/:id", apiController.getUserHandler);
+// Routes below tested within group function
 
-app.post("/api", middleware.mwOne, middleware.mwTwo, apiController.postHandler);
+// app.get("/api/users/:id", apiController.getUserHandler);
+
+// app.post("/api", middleware.mwOne, middleware.mwTwo, apiController.postHandler);
 
 app.put("/api", apiController.putHandler);
 


### PR DESCRIPTION
This pull request provides the code for modularising routes for a certain base path.

Features implemented:

- `group` method, which processes all the routes for the given base path.
- `register` method, which prepends the base path to the route path being stored in the object.

Looking forward to your feedback and suggestions!